### PR TITLE
Fix heap tag in Compiling a Lisp 4 post

### DIFF
--- a/_posts/2020-09-05-compiling-a-lisp-4.md
+++ b/_posts/2020-09-05-compiling-a-lisp-4.md
@@ -128,7 +128,7 @@ though.
 
 ```c
 const unsigned int kPairTag = 0x1;        // 0b001
-const uword kHeapTagMask = ((uword)0x7);  // 0b000...001
+const uword kHeapTagMask = ((uword)0x7);  // 0b000...0111
 const uword kHeapPtrMask = ~kHeapTagMask; // 0b1111...1000
 ```
 


### PR DESCRIPTION
Update comment to reflect code.