### PR TITLE
Add dark theme

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -3,9 +3,23 @@
 ---
 @charset "utf-8";
 
+a[href] {
+  @media (prefers-color-scheme: dark) {
+    color: steelblue;
+
+    &:visited {
+      color: plum;
+    }
+  }
+}
+
 body {
     /* margin: 0; */
     font-family: serif;
+    @media (prefers-color-scheme: dark) {
+        color: white;
+        background: black;
+    }
 }
 div.pagecontents {
     margin: 20px auto 0px auto;
@@ -19,6 +33,9 @@ div.navbar {
     padding: 10px;
     /* Thanks, oilshell.org, for inspiration. */
     background-color: #DEE;
+    @media (prefers-color-scheme: dark) {
+        background-color: #212121;
+    }
 }
 li.post-item {
     display: table;
@@ -49,6 +66,9 @@ aside {
 }
 code, pre {
     max-width: 650px;
+    @media (prefers-color-scheme: dark) {
+      color: black;
+    }
 }
 pre {
     overflow: auto;
@@ -81,10 +101,18 @@ table {
   table tr {
     border-top: 1px solid #cccccc;
     background-color: white;
+    @media (prefers-color-scheme: dark) {
+        border-top: 1px solid #555;
+        background-color: #121212;
+    }
     margin: 0;
     padding: 0; }
     table tr:nth-child(2n) {
-      background-color: #f8f8f8; }
+      background-color: #f8f8f8;
+      @media (prefers-color-scheme: dark) {
+        background-color: #212121;
+      }
+    }
     table tr th {
       font-weight: bold;
       border: 1px solid #cccccc;


### PR DESCRIPTION
This adds a basic dark theme to the global SCSS by using the `prefers-color-scheme` media query.
Some of the colors are arbitrary. You might want to tweak them to your liking, especially the navbar background color (finding something with good contrast is hard!).

PS: If you add the `hacktoberfest` topic to this repository pull requests like [this count towards me getting a t-shirt & stickers](https://hacktoberfest.digitalocean.com/)