### PR TITLE
Remove length of prefixes in big picture

### DIFF
--- a/_posts/2020-10-18-compiling-a-lisp-10.md
+++ b/_posts/2020-10-18-compiling-a-lisp-10.md
@@ -170,7 +170,7 @@ general layout for Intel instructions.
 
 All Intel x86-64 instructions follow this general format:
 
-* *optional* instruction prefix (1 byte)
+* *optional* instruction prefix
 * opcode (1, 2, or 3 bytes)
 * *if required,* Mod-Reg/Opcode-R/M, also known as ModR/M (1 byte)
 * *if required,* Scale-Index-Base, also known as SIB (1 byte)


### PR DESCRIPTION
Hi!

First things first, I like your blog, keep up the good work!

I think there is a mistake in the "Instruction encoding, big picture" section of the "Compiling a Lisp: Instruction encoding interlude" post. Basically, according to "2.1.1 Instruction Prefixes" only one prefix code from each prefix group is "useful", but multiple prefix codes (1 byte each) from different prefix groups are allowed. So, the length of the prefix part is not limited to one byte.

Best wishes,
Jon Dybeck
