### PR TITLE
Moved delcaration of ExecuteSpecialized out of ifdef to fix bug.

### DIFF
--- a/_posts/2024-05-19-weval.md
+++ b/_posts/2024-05-19-weval.md
@@ -287,9 +287,10 @@ uword Execute(uword *program) {
     // ...
 }
 
-#ifdef DO_WEVAL
+
 Object (*ExecuteSpecialized)(uword *) = 0;
 
+#ifdef DO_WEVAL
 void init() {
   uword result = 0;
   uword loopc = 1;


### PR DESCRIPTION
Moved the declaration of ExecuteSpecialized out of the #ifdef DO_WEVAL.

In main() the value is tested, and if DO_WEVAL is not set, it won't exist to test.