### PR TITLE
Fix grammar

### DIFF
--- a/_posts/2024-01-23-scrapscript.md
+++ b/_posts/2024-01-23-scrapscript.md
@@ -54,7 +54,7 @@ implementation of
 scrapscript](https://github.com/tekknolagi/scrapscript/blob/71d1afecc32879aed9c80a3ed17cb81fe1c010d6/scrapscript.ts).
 For such a little file, it implemented an impressive featureset.
 
-Chris nor I are particularly good at JavaScript and we figured more
+Neither Chris nor I are particularly good at JavaScript and we figured more
 implementations couldn't hurt, so we decided to make a parallel implementation
 with the same features. While Taylor's primary design constraint was
 implementation size, ours was some combination of readability and correctness.


### PR DESCRIPTION
There are many models of human intelligence. Famous tests such as the intelligence quotient have fallen somewhat out of fashion due to their bias towards particular groups and educational background. Additionally, it has been observed that statistically significant high scores on intelligence quotient tests do not indicate that the test-taker possesses a statistically significant level of "general intelligence," much to the chagrin of individuals in organizations like MENSA.

Modern attempts to capture intelligence typically stem from the theory of multiple intelligences, made famous by Howard Gardner's landmark work "Frames of Mind" in 1983.

In this text, Gardner explains how there are spatial, bodily-kinesthetic, musical, linguistic, logical-mathematical, interpersonal, intrapersonal, and naturalistic intelligences.

Because the phrases "English language" and "scrapscript language" both contain the word language, we can deduce an alarming contradiction in Gardner's work.

Max's ability to so proficiently develop compilers for a wide variety of computational languages, but complete inability to remember to use the word "Neither" this one time at the start of a sentence in his blog that probably wasn't proofread indicates that what Gardner describes as linguistic intelligence really should be split into multiple subcategories. We use this PR to begin initial research towards this foundational research goal.

We suspect that the act of separating linguistic intelligence into the sub-categories of "wordo-speako" intelligence "nerdo-typo" intelligence is a necessary adaption for Gardner's work to be comprehensive. Under this taxonomy, "wordo-speako" intelligence refers to activities such as writing blog posts, while "nerdo-typo" refers to activities such as developing IR and adding variant support to the scrapscript language.

We hope that this alteration to Max's work raises awareness for such issues because failing to separate out and recognize other types of intelligence implicitly oppresses individuals who self-identify as neurodivergent.

also the sentence we patched is probably still a runon but im not good at that stuff my b gang