### PR TITLE
Update `2025-08-13-liveness-datalog.md` to exclude `compute_initial_liveness_sets`

### DIFF
--- a/_posts/2025-08-13-liveness-datalog.md
+++ b/_posts/2025-08-13-liveness-datalog.md
@@ -221,46 +221,24 @@ code! Let's compare to our Ruby code from the previous post to underscore the
 point:
 
 ```ruby
-class Function
-  def compute_initial_liveness_sets order
-    gen = Hash.new 0
-    kill = Hash.new 0
-    order.each do |block|
-      block.instructions.reverse_each do |insn|
-        out = insn.out&.as_vreg
-        if out
-          kill[block] |= (1 << out.num)
-        end
-        insn.vreg_ins.each do |vreg|
-          gen[block] |= (1 << vreg.num)
-        end
-      end
-      block.parameters.each do |param|
-        kill[block] |= (1 << param.num)
+def analyze_liveness
+  order = post_order
+  gen, kill = compute_initial_liveness_sets(order)
+  live_in = Hash.new 0
+  changed = true
+  while changed
+    changed = false
+    for block in order
+      block_live = block.successors.map { |succ| live_in[succ] }.reduce(0, :|)
+      block_live |= gen[block]
+      block_live &= ~kill[block]
+      if live_in[block] != block_live
+        changed = true
+        live_in[block] = block_live
       end
     end
-    [gen, kill]
   end
-
-  def analyze_liveness
-    order = post_order
-    gen, kill = compute_initial_liveness_sets(order)
-    live_in = Hash.new 0
-    changed = true
-    while changed
-      changed = false
-      for block in order
-        block_live = block.successors.map { |succ| live_in[succ] }.reduce(0, :|)
-        block_live |= gen[block]
-        block_live &= ~kill[block]
-        if live_in[block] != block_live
-          changed = true
-          live_in[block] = block_live
-        end
-      end
-    end
-    live_in
-  end
+  live_in
 end
 ```
 


### PR DESCRIPTION
I think it's technically unfair to compare the part of the Ruby code which computed the liveness sets, since we just hardcoded that for the Datalog example.