### PR TITLE
Update `2025-08-13-liveness-datalog.md` with spaces around `;`

### DIFF
--- a/_posts/2025-08-13-liveness-datalog.md
+++ b/_posts/2025-08-13-liveness-datalog.md
@@ -173,7 +173,7 @@ think that is only because of Souffle's choice of syntax.
 ```
 // liveness.dl
 // ...
-live_in(b, v) :- (live_out(b, v); block_use(b, v)), !block_def(b, v).
+live_in(b, v) :- (live_out(b, v) ; block_use(b, v)), !block_def(b, v).
 ```
 
 It reads as "a variable `v` is live-in to `b` if it is either live-out of `b`


### PR DESCRIPTION
The `;` operator acts as a binary operator rather than a separator, so I think it's appropriate to format it as such. I also saw this formatting in the Soufflé documentation somewhere.