### PR TITLE
Verifier needs to check colors in set

### DIFF
--- a/_posts/2026-08-07-zkp.md
+++ b/_posts/2026-08-07-zkp.md
@@ -411,14 +411,16 @@ The verifier can check that the color+nonce hashes to the hash value given for
 each node in step P1. This ensures that the prover is not changing colors
 around mid-round. This relies on the verifier and the prover using the same
 hash function (and the same hash seed if using `hash`).
-The verifier also checks that the colors of the two nodes at each end of the edge 
-is a color of the publicly agreed on colors. 
+
+The verifier must also check that the colors of the two nodes at each end of
+the edge is a member of the publicly agreed on color set. Otherwise, the prover
+could color every node a different color.
 
 ```python
 # Only verifier
 for (node, (color, nonce)) in revealed.items():
     assert hashed_coloring[node] == hash((color, nonce)), f"Hash mismatch!"
-    assert color in all_colors, "Invalid color" 
+    assert color in all_colors, f"Invalid color {color}!"
 ```
 
 The verifier can then inspect that the two color values are different. This
@@ -426,7 +428,7 @@ gives a small amount of credence (`1/|E|` because you know something about one
 edge now) that the graph is 3-colored appropriately because the prover had no
 way of knowing which edge the verifier would want to inspect.
 
-If either of these tree conditions doesn't check out, the verifier *rejects*.
+If any of these conditions don't check out, the verifier *rejects*.
 
 ## Probabilities
 

--- a/_posts/2026-08-07-zkp.md
+++ b/_posts/2026-08-07-zkp.md
@@ -411,11 +411,14 @@ The verifier can check that the color+nonce hashes to the hash value given for
 each node in step P1. This ensures that the prover is not changing colors
 around mid-round. This relies on the verifier and the prover using the same
 hash function (and the same hash seed if using `hash`).
+The verifier also checks that the colors of the two nodes at each end of the edge 
+is a color of the publicly agreed on colors. 
 
 ```python
 # Only verifier
 for (node, (color, nonce)) in revealed.items():
     assert hashed_coloring[node] == hash((color, nonce)), f"Hash mismatch!"
+    assert color in all_colors, "Invalid color" 
 ```
 
 The verifier can then inspect that the two color values are different. This
@@ -423,7 +426,7 @@ gives a small amount of credence (`1/|E|` because you know something about one
 edge now) that the graph is 3-colored appropriately because the prover had no
 way of knowing which edge the verifier would want to inspect.
 
-If either of these two conditions doesn't check out, the verifier *rejects*.
+If either of these tree conditions doesn't check out, the verifier *rejects*.
 
 ## Probabilities
 


### PR DESCRIPTION
While the formal overview mentions that the revealed colors needs to be in the set `{1,2,3}` the detailed description skips over this assertion. Without it, a prover can just color each node with a different color without knowing a 3-coloring and convince a verifier.