### PR TITLE
Truncate zkp confidence rather than rounding

### DIFF
--- a/_posts/2026-08-07-zkp.md
+++ b/_posts/2026-08-07-zkp.md
@@ -590,7 +590,9 @@ async function round(edges) {
                 paint(node, color);
             }
             const probability = 1 - Math.pow(1 - 1 / edges.length, i + 1);
-            const msg = `Success. Confident ${(probability * 100).toFixed(2)}%`;
+            // Truncate rather than round; we never quite get to 100%.
+            const confidence = (Math.floor(probability * 10000) / 100).toFixed(2);
+            const msg = `Success. Confident ${confidence}%`;
             logRound(msg);
             console.log(`Round ${i + 1}:`, msg);
             i += 1;


### PR DESCRIPTION
The demo showed 100.00% confidence, which was deceptive given our intent is to show getting arbitrarily close to 100%

<img width="702" height="660" alt="Screenshot 2026-08-16 at 10 36 02 PM" src="https://github.com/user-attachments/assets/424a2346-11d5-482c-bbf2-1145de5af6cf" />
